### PR TITLE
Updated to only publish version if on main branch

### DIFF
--- a/.github/workflows/docker-publish-version.yml
+++ b/.github/workflows/docker-publish-version.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-and-push-image:
     runs-on: "ubuntu-latest"
+    if: endsWith(github.event.base_ref, 'main') == true
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Added check in git job to only tag image with version if git tag pushed while on the main branch.